### PR TITLE
Add types, reorganize worker

### DIFF
--- a/.storybook/initialize_worker.js
+++ b/.storybook/initialize_worker.js
@@ -1,8 +1,0 @@
-import { setupWorker, rest } from "msw";
-const worker = setupWorker(
-  rest.get("http://localhost:3000/api/hello", (req, res, ctx) => {
-    return res(ctx.json({ name: "John Doe" }));
-  })
-);
-
-export const start = worker.start;

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,10 +1,21 @@
 import "../styles/globals.css";
-import { start } from "./initialize_worker";
-
 // https://github.com/vercel/next.js/issues/18393#issuecomment-909636489
 import * as NextImage from "next/image";
+import { setupWorker, rest } from "msw";
 
-start();
+// Make sure we're in a browser
+if (typeof global.process === "undefined") {
+  const worker = setupWorker();
+  // Apply default handlers... should be from a setup collection somewhere in a real implementation
+  worker.start(
+    rest.get("http://localhost:3000/api/hello", (req, res, ctx) => {
+      return res(ctx.json({ name: "John Doe" }));
+    })
+  );
+
+  // Assign it to the window for re-use in stories
+  window.msw = { worker, rest };
+}
 
 const OriginalNextImage = NextImage.default;
 

--- a/globals.d.ts
+++ b/globals.d.ts
@@ -1,0 +1,6 @@
+declare interface Window {
+  msw: {
+    rest: typeof import("msw").rest;
+    worker: import("msw").SetupWorkerApi;
+  };
+}

--- a/pages/index.stories.tsx
+++ b/pages/index.stories.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { ComponentStory, ComponentMeta } from "@storybook/react";
 import "../styles/Home.module.css";
+import { rest } from "msw";
 
 import Home, { getServerSideProps } from "./index";
 
@@ -17,6 +18,23 @@ export const Basic = (
   return <Home {...serverSideProps} {...args} />;
 };
 Basic.loaders = [
+  () => {
+    // Looks like loaders are processed in insertion order, so being
+    // that we've started the worker in preview before we get close to the canvas
+    // worker.user is a sync process and will inject the handler to override the default.
+    // The neat thing here would be is use could use res.once multiple times and add
+    // a reload button to run through handlers with various outputs.
+    const { worker, rest } = window.msw;
+
+    worker.use(
+      rest.get("http://localhost:3000/api/hello", (req, res, ctx) => {
+        return res(
+          ctx.json({ name: "This will override the default handler" })
+        );
+      })
+    );
+    return {};
+  },
   async () => {
     let serverSideProps = await getServerSideProps();
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,25 +1,29 @@
-import type { NextPage } from "next";
+import type { GetServerSideProps, NextPage } from "next";
 import Head from "next/head";
 import Image from "next/image";
 import styles from "../styles/Home.module.css";
 import { AnchorCard } from "../modules/cards";
 
+type Data = {
+  name: string;
+};
+
 export async function getServerSideProps() {
-  const res = await fetch(`http://localhost:3000/api/hello`)
-  const data = await res.json()
+  const res = await fetch(`http://localhost:3000/api/hello`);
+  const data = await res.json();
 
   if (!data) {
     return {
       notFound: true,
-    }
+    };
   }
 
   return {
     props: data,
-  }
+  };
 }
 
-const Home: NextPage = (props) => {
+const Home: NextPage<Data> = (props) => {
   return (
     <div className={styles.container}>
       <Head>


### PR DESCRIPTION
Goals:
- Start the worker in preview.js before we deal with any stories
- Inject handlers as the first entry in loaders to guarantee you're overriding existing handlers _(established at worker.start)_
- Party :tada: 